### PR TITLE
ci: github actions設定修正

### DIFF
--- a/.github/workflows/assign_author.yml
+++ b/.github/workflows/assign_author.yml
@@ -1,7 +1,12 @@
+name: Assign author
+
 on:
   pull_request:
     types: [opened]
-name: Assign author
+
+permissions:
+  pull-requests: write
+
 jobs:
   assignAuthor:
     name: Assign author to PR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
         id: node_modules_cache
         uses: actions/cache@v4
         with:
-          save-always: true
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-${{ matrix.node-version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
         id: node_modules_cache
         uses: actions/cache@v4
         with:
-          save-always: true
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-${{ matrix.node-version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |


### PR DESCRIPTION
- assign authorアクションの権限不足修正
- actions/cacheのsave-alwaysオプションが非推奨となるため、削除