### PR TITLE
Node.jsのバージョン変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ["18", "20", "22"]
+        node-version: [18, 20, 22]
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ["20"]
+        node-version: [22]
 
     steps:
       - name: Checkout

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "ES2022",
+    "module": "ES2022",
     "moduleResolution": "Bundler",
-    "lib": ["ES2020"],
+    "lib": ["ES2023"],
     "declaration": true,
     "sourceMap": true,
     "esModuleInterop": true,


### PR DESCRIPTION
- GitHub Actions実行時のバージョンを22に変更
- 出力コードは、ES2022対応コードを指定