### PR TITLE
ci: npmjsの認証トークンはpublish時のみ指定する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org/"
           scope: "@gahojin-inc"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Publish
         run: pnpm -r publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
post_installスクリプトによる詐取が行われないようにする