### PR TITLE
chore: bump version 2026.7.2 -> 2026.8.0

### DIFF
--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = "v2026.7.2"
+current_version = "v2026.8.0"
 version_pattern = "vYYYY.MM.INC0"
 commit_message = "chore: bump version {old_version_pep440} -> {new_version_pep440}"
 pre_commit_hook = ""

--- a/packages/middy-appsync/package.json
+++ b/packages/middy-appsync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gahojin-inc/middy-appsync",
-  "version": "2026.7.2",
+  "version": "2026.8.0",
   "description": "Middy appsync",
   "author": "GAHOJIN, Inc.",
   "license": "Apache-2.0",

--- a/packages/middy-dynamodb-partial-batch-failure/package.json
+++ b/packages/middy-dynamodb-partial-batch-failure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gahojin-inc/middy-dynamodb-partial-batch-failure",
-  "version": "2026.7.2",
+  "version": "2026.8.0",
   "description": "Middy dynamodb partial batch failure",
   "author": "GAHOJIN, Inc.",
   "license": "Apache-2.0",

--- a/packages/middy-http-body-parser/package.json
+++ b/packages/middy-http-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gahojin-inc/middy-http-body-parser",
-  "version": "2026.7.2",
+  "version": "2026.8.0",
   "description": "Middy HTTP body parser",
   "author": "GAHOJIN, Inc.",
   "license": "Apache-2.0",

--- a/packages/middy-http-signature/package.json
+++ b/packages/middy-http-signature/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gahojin-inc/middy-http-signature",
-  "version": "2026.7.2",
+  "version": "2026.8.0",
   "description": "Middy http signature",
   "author": "GAHOJIN, Inc.",
   "license": "Apache-2.0",

--- a/packages/middy-valibot-validator/package.json
+++ b/packages/middy-valibot-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gahojin-inc/middy-valibot-validator",
-  "version": "2026.7.2",
+  "version": "2026.8.0",
   "description": "Middy valibot validator",
   "author": "GAHOJIN, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リリース**
  * 各パッケージのバージョンを `2026.7.2` から `2026.8.0` に更新しました。
  * 新しいバージョンとしてリリースされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->